### PR TITLE
Fix farmersdelight:cabinets/wooden item tag

### DIFF
--- a/src/generated/resources/data/farmersdelight/tags/items/cabinets/wooden.json
+++ b/src/generated/resources/data/farmersdelight/tags/items/cabinets/wooden.json
@@ -1,5 +1,5 @@
 {
   "values": [
-    "dungeonsdelight:wormwood_door"
+    "dungeonsdelight:wormwood_cabinet"
   ]
 }

--- a/src/main/java/net/yirmiri/dungeonsdelight/datagen/DDItemTagGen.java
+++ b/src/main/java/net/yirmiri/dungeonsdelight/datagen/DDItemTagGen.java
@@ -381,7 +381,7 @@ public class DDItemTagGen extends ItemTagsProvider {
     //--- FARMER'S DELIGHT TAGS ---
     private void appendCabinets() {
         tag(ModTags.WOODEN_CABINETS)
-                .add(DDBlocks.WORMWOOD_DOOR.get().asItem())
+                .add(DDBlocks.WORMWOOD_CABINET.get().asItem())
         ;
     }
 


### PR DESCRIPTION
The tag contained the wrong item; `dungeonsdelight:wormwood_door` rather than `dungeonsdelight:wormwood_cabinet`